### PR TITLE
Handle old org redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting…</title>
+<script>window.location.replace("https://47degrees.github.io"+window.location.pathname);</script>

--- a/fetch/index.html
+++ b/fetch/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting…</title>
+<meta http-equiv="refresh" content="0; URL=https://47degrees.github.io/fetch/">
+<link rel="canonical" href="https://47degrees.github.io/fetch/">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Redirecting to new URL</title>
+<title>Redirecting…</title>
 <meta http-equiv="refresh" content="0; URL=https://www.47deg.com">
 <link rel="canonical" href="https://www.47deg.com">

--- a/index.html
+++ b/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to new URL</title>
+<meta http-equiv="refresh" content="0; URL=https://www.47deg.com">
+<link rel="canonical" href="https://www.47deg.com">

--- a/sbt-microsites/index.html
+++ b/sbt-microsites/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Redirecting to new URL</title>
+<title>Redirecting…</title>
 <meta http-equiv="refresh" content="0; URL=https://47degrees.github.io/sbt-microsites/">
 <link rel="canonical" href="https://47degrees.github.io/sbt-microsites/">

--- a/scalacheck-toolbox/index.html
+++ b/scalacheck-toolbox/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting…</title>
+<meta http-equiv="refresh" content="0; URL=https://47degrees.github.io/scalacheck-toolbox/">
+<link rel="canonical" href="https://47degrees.github.io/scalacheck-toolbox/">


### PR DESCRIPTION
This PR handles the following redirects:

- [47deg.github.io/fetch](https://47deg.github.io/fetch/) -> [47degrees.github.io/fetch](https://47degrees.github.io/fetch/)
- [47deg.github.io/sbt-microsites](https://47deg.github.io/sbt-microsites/) -> [47degrees.github.io/sbt-microsites](https://47degrees.github.io/sbt-microsites/)
- [47deg.github.io/scalacheck-toolbox](https://47deg.github.io/scalacheck-toolbox/) -> [47degrees.github.io/scalacheck-toolbox ](https://47degrees.github.io/scalacheck-toolbox/)

Along a generic 404 that will be able to redirect other non root URLs.